### PR TITLE
Fix gem version variable for Docker image branch build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
       - run: |
           TAG=${CIRCLE_BRANCH}
           BRANCH=${CIRCLE_BRANCH}
+          VERSION=">= 0"
 
           if [ "${TAG}" == "master" ]; then
             TAG=latest
@@ -22,9 +23,10 @@ jobs:
           if [ -n "${CIRCLE_TAG}" ]; then
             TAG=${CIRCLE_TAG#v}
             BRANCH=${TAG/%.*/.x}
+            VERSION=${TAG}
           fi
 
-          docker build --build-arg branch=$BRANCH --build-arg version=$TAG -t cloudkeeper/cloudkeeper:$TAG .
+          docker build --build-arg branch=$BRANCH --build-arg version="$VERSION" -t cloudkeeper/cloudkeeper:$TAG .
           docker login -u $DOCKER_USER -p $DOCKER_PASS
           docker push cloudkeeper/cloudkeeper:$TAG
 deployment:

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ deb http://repository.egi.eu/sw/production/cas/1/current egi-igtf core' > /etc/a
     apt-get --assume-yes install ca-policy-egi-core
 
 # cloudkeeper
-RUN gem install ${name} -v ${version} --no-document
+RUN gem install ${name} -v "${version}" --no-document
 
 # env
 RUN useradd --system --shell /bin/false --home ${spoolDir} --create-home ${name} && \


### PR DESCRIPTION
Sorry about this. I fixed it in `cloudkeeper-one` but this one was already merged. That's actually how I found out since builds are run only on changes in `master` branch.