### PR TITLE
[Examples] Fixing missing run/lock dirs

### DIFF
--- a/examples/etc/init.d/cloudkeeper-cron
+++ b/examples/etc/init.d/cloudkeeper-cron
@@ -14,7 +14,17 @@ lockfile="/var/lock/cloudkeeper-cron"
 retval=0
 name=`basename $0`
 
+run_dir="/var/run/cloudkeeper"
+lock_dir="/var/lock/cloudkeeper"
+user="cloudkeeper"
+
+setup_dirs() {
+    mkdir -p "$run_dir" "$lock_dir"
+    chown "$user":"$user" "$run_dir" "$lock_dir"
+}
+
 start() {
+    setup_dirs
     touch $lockfile
     echo "Enabling periodic $name"
     retval=0


### PR DESCRIPTION
CentOS mounts `/var/lock` and `/var/run` as tmpfs and some dirs have to be created before starting the service.