### PR TITLE
Fix exception handling on appliances gRPC call

### DIFF
--- a/lib/cloudkeeper/backend_connector.rb
+++ b/lib/cloudkeeper/backend_connector.rb
@@ -56,7 +56,7 @@ module Cloudkeeper
         grpc_client.appliances(
           CloudkeeperGrpc::ImageListIdentifier.new(image_list_identifier: image_list_identifier),
           return_op: true
-        )
+        ), raise_exception: true
       ) do |response|
         response.inject({}) do |acc, elem|
           image = convert_image_proto(elem.image)


### PR DESCRIPTION
Solves the problem with exception handling for missing image.
Also requires a fix on the `cloudkeeper-one` side available here
https://github.com/the-cloudkeeper-project/cloudkeeper-one/pull/43