### PR TITLE
Remove 'original' attribute from ImageFile

### DIFF
--- a/lib/cloudkeeper/entities/image_file.rb
+++ b/lib/cloudkeeper/entities/image_file.rb
@@ -1,11 +1,11 @@
 module Cloudkeeper
   module Entities
     class ImageFile
-      attr_accessor :file, :format, :checksum, :size, :original
+      attr_accessor :file, :format, :checksum, :size
 
       include Cloudkeeper::Entities::Convertables::Convertable
 
-      def initialize(file, format, checksum, size, original = false)
+      def initialize(file, format, checksum, size)
         raise Cloudkeeper::Errors::ArgumentError, 'file, format, checksum and size cannot be nil nor empty'\
           if file.blank? || format.blank? || checksum.blank? || size.blank?
 
@@ -13,7 +13,6 @@ module Cloudkeeper
         @format = format
         @checksum = checksum
         @size = size
-        @original = original
 
         format_const_symbol = format.to_s.classify.to_sym
         extend(Cloudkeeper::Entities::Convertables.const_get(format_const_symbol)) \

--- a/lib/cloudkeeper/managers/image_manager.rb
+++ b/lib/cloudkeeper/managers/image_manager.rb
@@ -55,7 +55,7 @@ module Cloudkeeper
           retrieve_image(uri, filename)
 
           Cloudkeeper::Entities::ImageFile.new filename, format(filename), Cloudkeeper::Utils::Checksum.compute(filename),
-                                               File.size(filename), true
+                                               File.size(filename)
         rescue Cloudkeeper::Errors::InvalidURLError, Cloudkeeper::Errors::Image::Format::RecognitionError,
                Cloudkeeper::Errors::ArgumentError, Cloudkeeper::Errors::NetworkConnectionError, ::IOError => ex
           raise Cloudkeeper::Errors::Image::DownloadError, "Image #{url.inspect} download error: #{ex.message}"

--- a/spec/cloudkeeper/entities/convertables/convertable_spec.rb
+++ b/spec/cloudkeeper/entities/convertables/convertable_spec.rb
@@ -38,7 +38,6 @@ describe Cloudkeeper::Entities::Convertables::Convertable do
       expect(image_file.file).to eq(convertable_instance_raw.file)
       expect(image_file.format).to eq(:raw)
       expect(image_file.checksum).to eq(convertable_instance_raw.checksum)
-      expect(image_file.original).to be_falsy
     end
   end
 
@@ -83,7 +82,6 @@ describe Cloudkeeper::Entities::Convertables::Convertable do
         expect(image_file.file).to eq(convertable_instance_qcow2.file)
         expect(image_file.format).to eq(:qcow2)
         expect(image_file.checksum).to eq(convertable_instance_qcow2.checksum)
-        expect(image_file.original).to be_falsy
       end
     end
   end
@@ -106,7 +104,6 @@ describe Cloudkeeper::Entities::Convertables::Convertable do
         expect(image_file.file).to eq(convertable_instance_qcow2.file)
         expect(image_file.format).to eq(:qcow2)
         expect(image_file.checksum).to eq(convertable_instance_qcow2.checksum)
-        expect(image_file.original).to be_falsy
       end
     end
 

--- a/spec/cloudkeeper/entities/convertables/ova_spec.rb
+++ b/spec/cloudkeeper/entities/convertables/ova_spec.rb
@@ -161,7 +161,6 @@ describe Cloudkeeper::Entities::Convertables::Ova do
       expect(vmdk_image.file).to eq(convertable_instance_vmdk.file)
       expect(vmdk_image.format).to eq(convertable_instance_vmdk.format)
       expect(vmdk_image.checksum).to eq(convertable_instance_vmdk.checksum)
-      expect(vmdk_image.original).to be_falsy
     end
   end
 
@@ -193,7 +192,6 @@ describe Cloudkeeper::Entities::Convertables::Ova do
       expect(image_file.file).to eq(convertable_instance_qcow2.file)
       expect(image_file.format).to eq(:qcow2)
       expect(image_file.checksum).to eq(convertable_instance_qcow2.checksum)
-      expect(image_file.original).to be_falsy
     end
   end
 

--- a/spec/cloudkeeper/entities/image_file_spec.rb
+++ b/spec/cloudkeeper/entities/image_file_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Cloudkeeper::Entities::ImageFile do
-  subject(:image_file) { described_class.new '/some/file.raw', :raw, '123456', 555, true }
+  subject(:image_file) { described_class.new '/some/file.raw', :raw, '123456', 555 }
 
   describe '#new' do
     context 'when not OVA image' do
@@ -15,7 +15,7 @@ describe Cloudkeeper::Entities::ImageFile do
     end
 
     context 'when OVA image' do
-      subject(:image_file) { described_class.new '/some/file.ova', :ova, '123456', 666, true }
+      subject(:image_file) { described_class.new '/some/file.ova', :ova, '123456', 666 }
 
       it 'returns ImageFile instance' do
         expect(image_file).to be_instance_of described_class

--- a/spec/cloudkeeper/managers/image_manager_spec.rb
+++ b/spec/cloudkeeper/managers/image_manager_spec.rb
@@ -256,7 +256,6 @@ describe Cloudkeeper::Managers::ImageManager do
           expect(image_file.format).to eq(:qcow2)
           expect(image_file.checksum).to eq('9a8093f874bdf4c19b6deacd2208e347292452df008a61d815dcd8395a2487e263364a85ca569d71c27dd9e' \
                                             '349fd31227094644c39e9a734b199b2dbdefa9c35')
-          expect(image_file.original).to be_truthy
           expect(image_file.size).to eq(524_288)
         end
       end


### PR DESCRIPTION
This attribute was useless and was never used for anything. I don't even
remember what it was supposed to do.