### PR TITLE
Add checksum check after image download

### DIFF
--- a/lib/cloudkeeper/errors/image.rb
+++ b/lib/cloudkeeper/errors/image.rb
@@ -3,6 +3,7 @@ module Cloudkeeper
     module Image
       autoload :Format, 'cloudkeeper/errors/image/format'
       autoload :DownloadError, 'cloudkeeper/errors/image/download_error'
+      autoload :ChecksumError, 'cloudkeeper/errors/image/checksum_error'
       autoload :ConversionError, 'cloudkeeper/errors/image/conversion_error'
     end
   end

--- a/lib/cloudkeeper/errors/image/checksum_error.rb
+++ b/lib/cloudkeeper/errors/image/checksum_error.rb
@@ -1,0 +1,7 @@
+module Cloudkeeper
+  module Errors
+    module Image
+      class ChecksumError < StandardError; end
+    end
+  end
+end

--- a/lib/cloudkeeper/utils/appliance.rb
+++ b/lib/cloudkeeper/utils/appliance.rb
@@ -27,7 +27,7 @@ module Cloudkeeper
       end
 
       def prepare_image!(appliance)
-        image_file = Cloudkeeper::Managers::ImageManager.download_image(appliance.image.uri)
+        image_file = Cloudkeeper::Managers::ImageManager.secure_download_image(appliance.image.uri, appliance.image.checksum)
         appliance.image.add_image_file image_file
         return if acceptable_formats.include? image_file.format
 


### PR DESCRIPTION
When downloaded, image checksum (SHA512) is computed and compared to the
checksum information from image list. If checksums don't match an error
is raised.