### PR TITLE
Fix image list expiration

### DIFF
--- a/lib/cloudkeeper/utils/appliance.rb
+++ b/lib/cloudkeeper/utils/appliance.rb
@@ -1,8 +1,8 @@
 module Cloudkeeper
   module Utils
     module Appliance
-      def log_expired(appliance, message)
-        logger.info "#{message} #{appliance.identifier.inspect}"
+      def log_expired(expirable, message)
+        logger.info "#{message} #{expirable.identifier.inspect}"
       end
 
       def clean_image_files(appliance)


### PR DESCRIPTION
Image list expiration was broken and even though image list was removed
from CMF due to expiration it was immediately registered as a new one.

Fix as follows:
In case image list (from AppDB) has expired there are two scenarios:
1) It's a new image list not registered in CMF. In that case this image
list is skipped and no appliances from this image list are registered in
CMF.
2) It's a known image list and its appliances are registered in CMF. In
that case all registered appliances are removed from CMF.