### PR TITLE
Add better return code handling

### DIFF
--- a/lib/cloudkeeper/managers/appliance_manager.rb
+++ b/lib/cloudkeeper/managers/appliance_manager.rb
@@ -27,6 +27,10 @@ module Cloudkeeper
         abort ex.message
       end
 
+      def errors
+        { backend_errors: backend_connector.errors, image_list_errors: image_list_manager.errors }
+      end
+
       private
 
       def sync_expired_image_lists

--- a/lib/cloudkeeper/managers/image_list_manager.rb
+++ b/lib/cloudkeeper/managers/image_list_manager.rb
@@ -6,10 +6,11 @@ require 'json'
 module Cloudkeeper
   module Managers
     class ImageListManager
-      attr_reader :image_lists, :openssl_store
+      attr_reader :image_lists, :openssl_store, :errors
 
       def initialize
         @image_lists = {}
+        @errors = false
 
         @openssl_store = OpenSSL::X509::Store.new
         @openssl_store.add_path Cloudkeeper::Settings[:'ca-dir'] if Cloudkeeper::Settings[:'ca-dir']
@@ -33,6 +34,7 @@ module Cloudkeeper
           rescue Cloudkeeper::Errors::ImageList::DownloadError, Cloudkeeper::Errors::ImageList::VerificationError,
                  Cloudkeeper::Errors::Parsing::ParsingError => ex
             logger.warn "Image list #{url} couldn't be downloaded\n#{ex.message}"
+            @errors = true
             next
           end
         end


### PR DESCRIPTION
cloudkeeper is always trying to do as much as possible, which entails
ignoring errors during the run which it can recover from. Unfortunately
there was no way (other then going through the logs) to know whether the
run was successful or such errors occured.

cloudkeeper now keeps information about ignored errors and at the end of
its run a proper system status code can be returned. There are two such
status codes available
11 - error(s) occured during image list processing
12 - error(s) occured on the backend side

Close #56