### PR TITLE
Add support for multiple image-list in the configuration

### DIFF
--- a/lib/cloudkeeper/managers/image_list_manager.rb
+++ b/lib/cloudkeeper/managers/image_list_manager.rb
@@ -15,8 +15,10 @@ module Cloudkeeper
 
       def download_image_list
         logger.debug 'Downloading fresh image lists...'
-        url = Cloudkeeper::Settings[:'image-list']
-        Dir.mktmpdir('cloudkeeper') { |dir| retrieve_image_list url, dir }
+        urls = Cloudkeeper::Settings[:'image-list']
+        for url in urls
+          Dir.mktmpdir('cloudkeeper') { |dir| retrieve_image_list url, dir }
+        end
       rescue Cloudkeeper::Errors::ImageList::DownloadError, Cloudkeeper::Errors::ImageList::VerificationError,
              Cloudkeeper::Errors::Parsing::ParsingError, OpenSSL::PKCS7::PKCS7Error, JSON::ParserError => ex
         raise Cloudkeeper::Errors::ImageList::ImageListError, "Image list #{url.inspect} couldn't be downloaded\n#{ex.message}"


### PR DESCRIPTION
There is no support for multiple image-lists subscription in this version. 

With this change, it is possible to add multiple image lists. The format of the image-list parameter in the yml file changes from a string to an array:

```
image-list:
  - my-url1
  - my-url2
```