### PR TITLE
Add Net::HTTPFatalError to possible exceptions

### DIFF
--- a/lib/cloudkeeper/managers/image_manager.rb
+++ b/lib/cloudkeeper/managers/image_manager.rb
@@ -85,7 +85,7 @@ module Cloudkeeper
           end
         rescue Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, Errno::ECONNREFUSED, Net::HTTPBadResponse,
                Net::HTTPHeaderSyntaxError, EOFError, Net::HTTPServerException, Net::HTTPRetriableError,
-               OpenSSL::SSL::SSLError => ex
+               Net::HTTPFatalError, OpenSSL::SSL::SSLError => ex
           raise Cloudkeeper::Errors::NetworkConnectionError, ex
         end
 


### PR DESCRIPTION
Avoids issues with images showing a 504 error, e.g.
```
2022-08-01T18:57:38+00:00 [ERROR] 1 : Unexpected error: 504 "Gateway Time-out"
/usr/local/lib/ruby/2.6.0/net/http/response.rb:122:in `error!': 504 "Gateway Time-out" (Net::HTTPFatalError)
        from /usr/local/lib/ruby/2.6.0/net/http/response.rb:131:in `value'
        from /usr/local/bundle/gems/cloudkeeper-1.7.1/lib/cloudkeeper/managers/image_manager.rb:74:in `block (2 levels) in retrieve_image'
...
```
